### PR TITLE
Ardcont compliance checkpoint 1

### DIFF
--- a/include/ntrb/AudioBuffer.h
+++ b/include/ntrb/AudioBuffer.h
@@ -109,6 +109,10 @@ typedef struct{
 	*/
 	size_t monochannel_samples;
 	
+	///\todo doc this
+	size_t stdaud_buffer_first_frame;
+	size_t stdaud_next_buffer_first_frame;
+	
 	/**
 	A union containing source-specifc data required to read the audio from a source.
 	
@@ -144,7 +148,7 @@ typedef struct{
 	The audio engine loop will acknowledge and act on the error **after** the buffer contents is read from,
 	which means the buffer must contain no garbage in almost every type of error.
 	*/
-	enum ntrb_AudioBufferLoad_Error load_err;	
+	enum ntrb_AudioBufferLoad_Error load_err;
 } ntrb_AudioBuffer;
 
 /**

--- a/include/ntrb/BufferSource_FLACfile.h
+++ b/include/ntrb/BufferSource_FLACfile.h
@@ -52,10 +52,10 @@ typedef struct{
 	uint64_t buffersize_bytes;
 	///Keeps track of how many bytes read_bytes currently contain. 
 	uint64_t bytes_in_buffer;
-	///The audio frame (not FLAC frame) which the decoder has decoded to.
-	uint64_t current_frame;
 	///This contains the information of the FLAC file from its metadata.
 	ntrb_AudioHeader aud_header;
+	
+	float file_samplerate_over_stdaud;
 } ntrb_BufferSource_FLACfile;
 
 #ifdef __cplusplus

--- a/include/ntrb/BufferSource_WAVfile.h
+++ b/include/ntrb/BufferSource_WAVfile.h
@@ -46,11 +46,16 @@ typedef struct{
 	ntrb_AudioHeader aud_header;
 	
 	/**
+	\todo !!!
+	\attention nope
 	It initially contains the amount of bytes of audio data in the file.
 	But in every call of ntrb_BufferSource_WAVfile_load_buffer(), this gets reduced by ntrb_BufferSource_WAVfile.bytes_to_read.
 	If this reaches 0 during the subtraction in the function, it indicates and end of file and the function stops reading the file.
 	*/
 	size_t audiodataSize;
+	size_t audiodataOffset;
+	
+	float file_samplerate_over_stdaud;
 } ntrb_BufferSource_WAVfile;
 
 #ifdef __cplusplus

--- a/include/ntrb/aud_std_fmt.h
+++ b/include/ntrb/aud_std_fmt.h
@@ -115,41 +115,6 @@ If the function failed to allocate the return container, it returns failed_ntrb_
 ntrb_AudioDatapoints ntrb_to_samplerate(const ntrb_AudioDatapoints orig, const uint32_t orig_samplerate, const uint32_t dest_samplerate);
 
 /**
-Returns a separately allocated ret_aud which is either a clone of orig or a float32 converted orig, if orig is float32 or int16 respectively.
-
-- If an ntrb_StdAudFmtConversion_AllocFailure is returned, ret_aud couldn't be allocated.
-- If an ntrb_StdAudFmtConversion_UnknownSampleFormat is returned, originalFormat is not supported.
-*/
-enum ntrb_StdAudFmtConversionResult ntrb_to_std_sample_fmt(ntrb_AudioDatapoints* const ret_aud, const ntrb_AudioDatapoints orig, const PaSampleFormat originalFormat);
-
-/**
-Returns a separately allocated ret_aud which is either a clone of orig or a stereo converted orig, if orig is stereo or mono respectively.
-
-orig must be in float32 format.
-
-- If an ntrb_StdAudFmtConversion_AllocFailure is returned, ret_aud couldn't be allocated.
-- If an ntrb_StdAudFmtConversion_UnsupportedChannels is returned, audchannels is not supported.
-
-\param[out] ret_aud Uninitialised ntrb_AudioDatapoints for output.
-\param[in] orig
-\param[in] audchannels Audio channel count of orig.
-*/
-enum ntrb_StdAudFmtConversionResult ntrb_to_std_aud_channels(ntrb_AudioDatapoints* const ret_aud, const ntrb_AudioDatapoints orig, const uint8_t audchannels);
-
-/**
-Returns a separately allocated ret_aud which is either a copy of orig or one converted to 48khz sample rate.
-
-orig must be in stereo channeled float32.
-
-If an ntrb_StdAudFmtConversion_AllocFailure is returned, ret_aud couldn't be allocated.
-
-\param[out] ret_aud Uninitialised ntrb_AudioDatapoints for output.
-\param[in] orig
-\param[in] samplerate Sample rate of orig.
-*/
-enum ntrb_StdAudFmtConversionResult ntrb_to_std_samplerate(ntrb_AudioDatapoints* const ret_aud, const ntrb_AudioDatapoints orig, const uint32_t samplerate);
-
-/**
 Returns a separately allocated ret_aud, which is orig converted to float32 stereo 48khz format.
 
 \param[out] ret_aud Uninitialised ntrb_AudioDatapoints for output.

--- a/include/ntrb/audeng_wrapper.h
+++ b/include/ntrb/audeng_wrapper.h
@@ -1,6 +1,8 @@
 #ifndef ntrb_audengwrapper_h
 #define ntrb_audengwrapper_h
 
+#include "portaudio.h"
+
 /*
 Copyright 2024 Pawikan Boonnaum
 
@@ -30,6 +32,8 @@ extern const unsigned long ntrb_std_frame_count;
 #ifdef __cplusplus
 extern "C"{	
 #endif
+
+PaError ntrb_get_output_stream_params(PaStreamParameters* const output_params);
 
 /**
 The function for the audio engine thread.

--- a/src/AudioBuffer.c
+++ b/src/AudioBuffer.c
@@ -40,6 +40,9 @@ enum ntrb_AudioBufferNew_Error ntrb_AudioBuffer_new(ntrb_AudioBuffer* const ret,
 	if(filetype == NULL)
 		return ntrb_AudioBufferNew_InvalidAudFiletype;
 
+	ret->stdaud_buffer_first_frame = 0;
+	ret->stdaud_next_buffer_first_frame = 0;
+
 	enum ntrb_AudioBufferNew_Error source_init_error = ntrb_AudioBufferNew_OK;
 	if(strcmp(filetype, "wav") == 0){
 		ret->load_buffer_callback = ntrb_BufferSource_WAVfile_load_buffer;
@@ -69,9 +72,6 @@ enum ntrb_AudioBufferNew_Error ntrb_AudioBuffer_new(ntrb_AudioBuffer* const ret,
 		ntrb_AudioBuffer_free(ret);
 		return ntrb_AudioBufferNew_AllocError;
 	}
-	
-	ret->stdaud_buffer_first_frame = 0;
-	ret->stdaud_next_buffer_first_frame = 0;
 	
 	return ntrb_AudioBufferNew_OK;
 }

--- a/src/AudioBuffer.c
+++ b/src/AudioBuffer.c
@@ -70,6 +70,9 @@ enum ntrb_AudioBufferNew_Error ntrb_AudioBuffer_new(ntrb_AudioBuffer* const ret,
 		return ntrb_AudioBufferNew_AllocError;
 	}
 	
+	ret->stdaud_buffer_first_frame = 0;
+	ret->stdaud_next_buffer_first_frame = 0;
+	
 	return ntrb_AudioBufferNew_OK;
 }
 

--- a/src/BufferSource_FLACfile.c
+++ b/src/BufferSource_FLACfile.c
@@ -157,6 +157,8 @@ void* ntrb_BufferSource_FLACfile_load_buffer(void* const void_ntrb_AudioBuffer){
 		aud->load_err = FLAC__StreamDecoderState_to_ntrb_AudioBufferLoad_Error(FLAC__stream_decoder_get_state(aud->source.flac_file.decoder));
 	}
 	
+	if(aud->load_err) return NULL;
+	
 	aud->stdaud_buffer_first_frame = aud->stdaud_next_buffer_first_frame;
 	aud->stdaud_next_buffer_first_frame += aud->monochannel_samples;
 	

--- a/src/BufferSource_FLACfile.c
+++ b/src/BufferSource_FLACfile.c
@@ -157,7 +157,10 @@ void* ntrb_BufferSource_FLACfile_load_buffer(void* const void_ntrb_AudioBuffer){
 		aud->load_err = FLAC__StreamDecoderState_to_ntrb_AudioBufferLoad_Error(FLAC__stream_decoder_get_state(aud->source.flac_file.decoder));
 	}
 	
-	if(aud->load_err) return NULL;
+	if(aud->load_err){
+		pthread_rwlock_unlock(&(aud->buffer_access));		
+		return NULL;
+	}
 	
 	aud->stdaud_buffer_first_frame = aud->stdaud_next_buffer_first_frame;
 	aud->stdaud_next_buffer_first_frame += aud->monochannel_samples;

--- a/src/BufferSource_FLACfile.c
+++ b/src/BufferSource_FLACfile.c
@@ -161,7 +161,7 @@ void* ntrb_BufferSource_FLACfile_load_buffer(void* const void_ntrb_AudioBuffer){
 	aud->stdaud_next_buffer_first_frame += aud->monochannel_samples;
 	
 	ntrb_AudioDatapoints stdaud;
-	const ntrb_AudioDatapoints unprocessed_aud = {.bytes = aud->source.flac_file.read_bytes, .byte_pos = 0, .byte_count = aud->source.flac_file.bytes_in_buffer};
+	const ntrb_AudioDatapoints unprocessed_aud = {.bytes = aud->source.flac_file.read_bytes, .byte_pos = 0, .byte_count = aud->source.flac_file.buffersize_bytes};
 	const enum ntrb_StdAudFmtConversionResult stdaud_conversion_error = ntrb_to_standard_format(&stdaud, unprocessed_aud, &(aud->source.flac_file.aud_header));
 	if(stdaud_conversion_error){
 		aud->load_err = ntrb_AudioBufferLoad_StdaudConversionError;

--- a/src/audeng_wrapper.c
+++ b/src/audeng_wrapper.c
@@ -105,7 +105,7 @@ static int stream_audio(const void *, void *output_void, unsigned long frameCoun
 }
 
 
-static PaError get_output_stream_params(PaStreamParameters* const output_params){
+PaError ntrb_get_output_stream_params(PaStreamParameters* const output_params){
 	output_params->device = Pa_GetDefaultOutputDevice();
 	if(output_params->device == paNoDevice) return paDeviceUnavailable;
 	
@@ -128,7 +128,7 @@ void* ntrb_run_audio_engine(void* const runtime_data_void){
 	if(pa_error) goto print_err;
 		
 	PaStreamParameters output_stream_params;
-	pa_error = get_output_stream_params(&output_stream_params);
+	pa_error = ntrb_get_output_stream_params(&output_stream_params);
 	if(pa_error) goto uninit_pa;
 	
 	//output_stream Alloc


### PR DESCRIPTION
Fixed a few FLAC bugs, introduced seeking via stdaud frames in ntrb_AudioBuffer, improved ntrb_to_standard_format() memory efficiency and now exports output_params in audeng_wrapper